### PR TITLE
Fix the handling of fetch_feature for homogeneous graphs

### DIFF
--- a/GIDS_Setup/GIDS/GIDS.py
+++ b/GIDS_Setup/GIDS/GIDS.py
@@ -436,11 +436,11 @@ class GIDS():
 
                 for i in range(num_iter):
                     batch = self.window_buffer[i]
-                    batch[0] = batch[0].to(self.gids_device)
-                    index_size = len(batch[0])
+                    index = batch[0].to(self.gids_device)
+                    index_size = len(index)
                     index_size_list.append(index_size)
                     return_torch =  torch.zeros([index_size,dim], dtype=torch.float, device=self.gids_device)
-                    index_ptr_list.append(batch[0].data_ptr())
+                    index_ptr_list.append(index.data_ptr())
                     return_torch_list.append(return_torch.data_ptr())
                     self.return_torch_buffer.append(return_torch)
 

--- a/evaluation/dataloader.py
+++ b/evaluation/dataloader.py
@@ -130,14 +130,14 @@ class IGB260MDGLDataset(DGLDataset):
         node_labels = torch.from_numpy(dataset.paper_label).to(torch.long)
 
         print("node edge:", node_edges)
-        #cur_path = osp.join(self.dir, self.args.dataset_size, 'processed')
-        cur_path = '/mnt/nvme16/IGB260M_part_2/full/processed'
-        edge_row_idx = torch.from_numpy(np.load(cur_path + '/paper__cites__paper/edge_index_csc_row_idx.npy'))
-        edge_col_idx = torch.from_numpy(np.load(cur_path + '/paper__cites__paper/edge_index_csc_col_idx.npy'))
-        edge_idx = torch.from_numpy(np.load(cur_path + '/paper__cites__paper/edge_index_csc_edge_idx.npy'))
+        cur_path = osp.join(self.dir, self.args.dataset_size, 'processed')
+        # cur_path = '/mnt/nvme16/IGB260M_part_2/full/processed'
         
 #        self.graph = dgl.graph((node_edges[:, 0],node_edges[:, 1]), num_nodes=node_features.shape[0])
         if self.args.dataset_size == 'full':   
+            edge_row_idx = torch.from_numpy(np.load(cur_path + '/paper__cites__paper/edge_index_csc_row_idx.npy'))
+            edge_col_idx = torch.from_numpy(np.load(cur_path + '/paper__cites__paper/edge_index_csc_col_idx.npy'))
+            edge_idx = torch.from_numpy(np.load(cur_path + '/paper__cites__paper/edge_index_csc_edge_idx.npy'))
             self.graph = dgl.graph(('csc', (edge_col_idx,edge_row_idx,edge_idx)), num_nodes=node_features.shape[0])
             self.graph  = self.graph.formats('csc') 
         else:


### PR DESCRIPTION
when running `homogeneous_train.py`, it reports that " 'tuple' object does not support item assignment" error as shown below:
<img width="537" alt="image" src="https://github.com/jeongminpark417/GIDS/assets/52373880/f86f506a-886c-40af-bce9-1d2b9fa7b150">
Because the batch is a tuple variable, changing the batch directly is not allowed